### PR TITLE
Fix NoMethodError in WebDAV unlock when token is nil

### DIFF
--- a/lib/dav4rack/resource.rb
+++ b/lib/dav4rack/resource.rb
@@ -317,6 +317,7 @@ module Dav4rack
     # Remove the given lock
     def unlock(token)
       return NotImplemented unless @lock_class
+      return BadRequest if token.nil?
 
       token = token.slice(1, token.length - 2)
       if token.blank?


### PR DESCRIPTION
## Problem

When a WebDAV client sends an UNLOCK request without a valid lock token (e.g. during error recovery or when using certain WebDAV client implementations), the `token` parameter passed to `Dav4rack::Resource#unlock` is `nil`.

The existing code on line 321 of `lib/dav4rack/resource.rb` calls:

```ruby
token = token.slice(1, token.length - 2)
```

This raises `NoMethodError: undefined method 'length' for nil` because `token.length` is called before the `token.blank?` check on line 322.

The error is caught by the WebDAV error handler but generates noisy log entries:

```
WebDAV Error: undefined method 'length' for nil
```

## Root Cause

The nil check was originally `if(token.nil? || token.empty?)` and was placed **after** the `token.slice()` call. This means a nil token always crashes before reaching the guard clause. The bug has existed since `dav4rack` was embedded in the plugin (commit `ead480f7`, 2019).

## Fix

Add an early return with `BadRequest` before attempting to slice the token. This is consistent with the existing `token.blank?` check below and prevents the NoMethodError.

```ruby
def unlock(token)
  return NotImplemented unless @lock_class
  return BadRequest if token.nil?  # <-- added

  token = token.slice(1, token.length - 2)
  ...
end
```