### PR TITLE
Adds missing Ruby Gem 'pstore' for Ruby 4 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,11 +22,12 @@ source 'https://rubygems.org' do
   gem 'activestorage'
   gem 'image_processing', '~> 1.2'
   gem 'ox' # Dav4Rack
+  gem 'pstore'
   gem 'rake' unless Dir.exist?(File.expand_path('../../redmine_dashboard', __FILE__))
   gem 'simple_enum'
   gem 'uuidtools'
   gem 'zip-zip' unless Dir.exist?(File.expand_path('../../vault', __FILE__))
-  gem 'pstore'
+
   group :xapian do
     gem 'xapian-ruby'
   end

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ source 'https://rubygems.org' do
   gem 'simple_enum'
   gem 'uuidtools'
   gem 'zip-zip' unless Dir.exist?(File.expand_path('../../vault', __FILE__))
+  gem 'pstore'
   group :xapian do
     gem 'xapian-ruby'
   end


### PR DESCRIPTION
Since Ruby 4 the Ruby Gem 'pstore' is no standard Gem anymore. It needs to be bundled instead.